### PR TITLE
Change fetchAPI return type

### DIFF
--- a/service_http/untitled/src/main/java/org/example/ServiceHttp.java
+++ b/service_http/untitled/src/main/java/org/example/ServiceHttp.java
@@ -1,11 +1,21 @@
 package org.example;
 
-import java.net.http.HttpResponse;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
 
+
+/**
+ * Remote service used to retrieve the body of an HTTP request.
+ */
 public interface ServiceHttp extends Remote {
 
-    HttpResponse<String> fetchAPI(String url) throws RemoteException;
+    /**
+     * Fetches the content of the given URL.
+     *
+     * @param url the address to request
+     * @return the response body as a string
+     * @throws RemoteException if a remote communication error occurs
+     */
+    String fetchAPI(String url) throws RemoteException;
 
 }


### PR DESCRIPTION
## Summary
- return response body as a `String`
- document `ServiceHttp.fetchAPI`

## Testing
- `javac service_http/untitled/src/main/java/org/example/ServiceHttp.java -d /tmp/out`
- `mvn -q test` *(fails: mvn not found)*

